### PR TITLE
Replace Bootstrap5 badge

### DIFF
--- a/app/views/proofs/_show.html.erb
+++ b/app/views/proofs/_show.html.erb
@@ -97,7 +97,7 @@
 	<% end %>
 	<br>
 	<% proof.steps.each do |i,s| %>
-		<span class="badge badge-secondary">
+		<span class="badge bg-secondary">
 			<%= i %>
 		</span>
 		<% if s[:conclusion] != :contradiction %>
@@ -121,7 +121,7 @@
 			<% elsif u.first == :axiom %>
 				<%= "A(#{u.second})" %>
 			<% elsif u.first == :step %>
-				<span class="badge badge-secondary">
+				<span class="badge bg-secondary">
 					<%= u.second %>
 				</span>
 			<% elsif u.first == :assumption %>


### PR DESCRIPTION
Related PR: https://github.com/MaMpf-HD/mampf/pull/463
where we upgrade Bootstrap from v4 to v5