### PR TITLE
Fix routing exceptions and nested forms issue

### DIFF
--- a/app/controllers/main_controller.rb
+++ b/app/controllers/main_controller.rb
@@ -1,5 +1,10 @@
 # Main controller
 class MainController < ApplicationController
+  skip_before_action :authenticate_user!, only: :error
   def search
   end
+
+  def error
+    redirect_to :root, alert: I18n.t("controllers.no_page")
+  end  
 end

--- a/app/views/axioms/_form.html.erb
+++ b/app/views/axioms/_form.html.erb
@@ -2,7 +2,7 @@
 							html: { id: 'axiomForm',
 											data:
 												{ properties: structure.deep_building_blocks_properties_select.to_json } } do |f| %>
-	<div class="form-row">
+	<div class="row">
 		<div class="col-5">
 			<%= f.select :stuff_w_props,
 									 options_for_select(structure.eligible_for_axiom_select, nil),

--- a/app/views/example_facts/_form.html.erb
+++ b/app/views/example_facts/_form.html.erb
@@ -1,13 +1,12 @@
 <%= form_with url: update_example_facts_path(example),
-              method: 'post',
-              scope: 'example_facts' do |f|%>
+              method: 'post' do |f|%>
   <% available_properties.each do |p| %>
     <div class="form-row">
       <div class="col-12">
         <div class="form-check mb-2">
-          <%= f.check_box "properties[#{p.id}]",
+          <%= f.check_box "example_facts[properties][#{p.id}]",
                           class: 'form-check-input' %>
-          <%= f.label "properties[#{p.id}]",
+          <%= f.label "example_facts[properties][#{p.id}]",
                       p.name,
                       { class: 'form-check-label' } %>
         </div>
@@ -22,12 +21,12 @@
     </div>
   </div>
   <div class="form-group">
-    <%= f.label :new_property,
+    <%= f.label "example_facts[new_property]",
                 t('property.edit.name') %>
-    <%= f.text_field :new_property,
+    <%= f.text_field "example_facts[new_property]",
                      class: 'form-control' %>
   </div>
-  <%= f.hidden_field :satisfied,
+  <%= f.hidden_field "example_facts[satisfied]",
                      value: satisfied %>
   <div class="row mt-4">
     <div class="col-12 text-center">

--- a/app/views/example_facts/_properties_form.html.erb
+++ b/app/views/example_facts/_properties_form.html.erb
@@ -1,13 +1,12 @@
 <%= form_with url: update_example_facts_to_property_path(property),
-              method: 'post',
-              scope: 'example_facts' do |f|%>
+              method: 'post' do |f|%>
   <% available_examples.each do |e| %>
     <div class="form-row">
       <div class="col-12">
         <div class="form-check mb-2">
-          <%= f.check_box "examples[#{e.id}]",
+          <%= f.check_box "example_facts[examples][#{e.id}]",
                           class: 'form-check-input' %>
-          <%= f.label "examples[#{e.id}]",
+          <%= f.label "example_facts[examples][#{e.id}]",
                       e.description,
                       { class: 'form-check-label' } %>
         </div>
@@ -32,13 +31,13 @@
                         remote: true)) %>
   <% else %>
     <div class="form-group">
-      <%= f.label :new_example,
+      <%= f.label "example_facts[new_example]",
                   t('example.edit.description') %>
-      <%= f.text_field :new_example,
+      <%= f.text_field "example_facts[new_example]",
                        class: 'form-control' %>
     </div>
   <% end %>
-  <%= f.hidden_field :satisfied,
+  <%= f.hidden_field "example_facts[satisfied]",
                      value: satisfied %>
   <div class="row mt-4">
     <div class="col-12 text-center">

--- a/app/views/implications/_form.html.erb
+++ b/app/views/implications/_form.html.erb
@@ -1,16 +1,17 @@
-<%= form_with model: implication,
-							html: { id: 'implicationForm',
-											data:
-												{ properties: structure.deep_building_blocks_properties_select.to_json } } do |f| %>
+<%= form_with url: implications_path(implication),
+			method: :post,
+        	html: { id: 'implicationForm',
+					data:
+					{ properties: structure.deep_building_blocks_properties_select.to_json } } do |f| %>
 	<div class="row mb-2">
 		<div class="col-12">
 			<%= t('implication.edit.premises') %>
 		</div>
 	</div>
 	<% 1.upto(5) do |i| %>
-	  <div class="form-row mb-2">
+	  <div class="row mb-2">
 		  <div class="col-5">
-			  <%= f.select "premises#{[i]}[stuff_w_props]",
+			  <%= f.select "implication[premises]#{[i]}[stuff_w_props]",
 			     				   options_for_select(structure.eligible_for_premise_select, nil),
 								     { prompt: t('basics.select') },
 	    						   { class: 'form-control atomStuffWProps',
@@ -18,13 +19,13 @@
 	    						 	   required: i == 1 } %>
 		  </div>
 		  <div class="col-2">
-			 <%= f.select "premises#{[i]}[value]",
+			 <%= f.select "implication[premises]#{[i]}[value]",
 			  						options_for_select([[t('logic.is'), 1],[t('logic.is_not'), 0]]),
 								    {},
 	    						  { class: 'form-control' } %>
 		  </div>
 		  <div class="col-5">
-			  <%= f.select "premises#{[i]}[satisfies]",
+			  <%= f.select "implication[premises]#{[i]}[satisfies]",
 			      				 [[]],
 								     { prompt: t('basics.select') },
 	    						   { class: 'form-control atomSatisfies',
@@ -41,9 +42,9 @@
 			<%= t('implication.edit.implies') %>
 		</div>
 	</div>
-	<div class="form-row">
+	<div class="row">
 		<div class="col-5">
-			<%= f.select 'implies[stuff_w_props]',
+			<%= f.select 'implication[implies][stuff_w_props]',
 									 options_for_select(structure.eligible_for_premise_select, nil),
 								   { prompt: t('basics.select') },
 	    						 { class: 'form-control atomStuffWProps',
@@ -51,13 +52,13 @@
 	    						 	 required: true } %>
 		</div>
 		<div class="col-2">
-			<%= f.select 'implies[value]',
+			<%= f.select 'implication[implies][value]',
 									 options_for_select([[t('logic.is'), 1],[t('logic.is_not'), 0]]),
 								   {},
 	    						 { class: 'form-control' } %>
 		</div>
 		<div class="col-5">
-			<%= f.select 'implies[satisfies]',
+			<%= f.select 'implication[implies][satisfies]',
 									 options_for_select(structure.properties.map { |p| [p.name, p.id] }, nil),
 								   { prompt: t('basics.select') },
 	    						 { class: 'form-control atomSatisfies',
@@ -82,6 +83,6 @@
  	   </button>
     </div>
   </div>
-  <%= f.hidden_field :structure_id,
-  									 value: structure.id %>
+  <%= f.hidden_field "implication[structure_id]",
+									 value: structure.id %>
 <% end %>

--- a/app/views/shared/_generic_modal.html.erb
+++ b/app/views/shared/_generic_modal.html.erb
@@ -13,12 +13,9 @@
           <%= title %>
         </h5>
         <button type="button"
-                class="close"
+                class="btn-close"
                 data-bs-dismiss="modal"
                 aria-label="Close">
-          <span aria-hidden="true">
-            &times;
-          </span>
         </button>
       </div>
       <div class="modal-body" id="<%= sort%>-modal-content">

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -286,3 +286,5 @@ de:
               axioms_violated: >
                 Die Baustein-Realisierungen verletzt Axiom(e) der
                 Baustein-Struktur.
+  controllers:
+    no_page: Seite nicht gefunden

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,6 +103,7 @@ en:
   controllers:
     no_structure: 'There is no structure with this id.'
     no_property: 'There is no property with this id.'
+    no_page: 'Page not found'
   buttons:
     edit: 'Edit'
   basics:
@@ -111,3 +112,4 @@ en:
     related_tags: Related Tags
   warnings:
     unsaved_changes: 'Ungespeicherte Änderungen'
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,4 +42,9 @@ Rails.application.routes.draw do
 
   get '/' => 'structures#index'
   root to: 'structures#index'
+
+  # redirect bs requests to error page
+
+  match "*path", to: "main#error", via: :all
+  match "/", to: "main#error", via: [:post, :put, :patch, :delete]  
 end


### PR DESCRIPTION
This PR fixes some more bugs:

- There is now a redirect to the error page for (most) requests of pages that do not exist
- Nested forms had been failing to due to the upgrade to Rack3, see also [here](https://github.com/MaMpf-HD/mampf/pull/632). The Rack team updated their UPGRADE Guide to [explain what is going wrong exactly](https://github.com/rack/rack/blob/main/UPGRADE-GUIDE.md#invalid-nested-query-parsing-syntax), I adjusted the code accordingly.